### PR TITLE
BatchJob get_status and get_result

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
         env:
           HUME_DEV_API_KEY: ${{ secrets.HUME_DEV_API_KEY }}
         run: |
-          poetry run pytest tests --cov=. --cov-report=html --cov-report=xml --cov-branch -m "not service"
+          poetry run pytest tests --cov=hume --cov-report=html --cov-report=xml --cov-branch -m "not service"
 
       - name: Run pydocstyle
         shell: bash

--- a/hume/batch/batch_job.py
+++ b/hume/batch/batch_job.py
@@ -25,6 +25,26 @@ class BatchJob:
         self._client = client
         self.id = job_id
 
+    def get_status(self) -> BatchJobStatus:
+        """Get the status of the job.
+
+        Returns:
+            BatchJobStatus: The status of the `BatchJob`.
+        """
+        return self.get_result().status
+
+    def get_result(self) -> BatchJobResult:
+        """Get the result of the BatchJob.
+
+        Note that the result of a job may be fetched before the job has completed.
+        You may want to use `job.await_complete()` which will wait for the job to
+        reach a terminal state before returning the result.
+
+        Returns:
+            BatchJobResult: The result of the `BatchJob`.
+        """
+        return self._client.get_job_result(self.id)
+
     def await_complete(self, timeout: int = 300) -> BatchJobResult:
         """Block until the job has reached a terminal status.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ build-backend = "poetry.core.masonry.api"
 requires = ["poetry-core>=1.0.0"]
 
 [tool.covcheck]
-branch = 65.0
-line = 75.0
+branch = 68.0
+line = 82.0
 
 [tool.flake8]
 ignore = ""           # Required to disable default ignores

--- a/tests/batch/test_batch_job.py
+++ b/tests/batch/test_batch_job.py
@@ -1,26 +1,48 @@
-from unittest.mock import MagicMock
+from unittest.mock import Mock
 
 import pytest
-from pytest import MonkeyPatch
 
-from hume import BatchJob, HumeBatchClient
+from hume import BatchJob, BatchJobResult, BatchJobStatus, ModelType
+from hume.common.config import FaceConfig
 
 
 @pytest.fixture(scope="function")
-def batch_client(monkeypatch: MonkeyPatch) -> HumeBatchClient:
-    mock_start_job = MagicMock(return_value="fake-job")
-    monkeypatch.setattr(HumeBatchClient, "start_job", mock_start_job)
-    return HumeBatchClient("0000-0000-0000-0000")
+def batch_client() -> Mock:
+    mock_client = Mock()
+    job_result = BatchJobResult(
+        configs={
+            ModelType.FACE: FaceConfig(),
+        },
+        urls="mock-url",
+        status=BatchJobStatus.FAILED,
+    )
+    mock_client.get_job_result = Mock(return_value=job_result)
+    return mock_client
 
 
 class TestBatchJob:
 
-    def test_job_id(self, batch_client: HumeBatchClient):
+    def test_job_id(self, batch_client: Mock):
         mock_job_id = "mock-job-id"
         job = BatchJob(batch_client, mock_job_id)
         assert job.id == mock_job_id
 
-    def test_invalid_await_timeout(self, batch_client: HumeBatchClient):
-        job = BatchJob(batch_client, "mock_job_id")
+    def test_invalid_await_timeout(self, batch_client: Mock):
+        job = BatchJob(batch_client, "mock-job-id")
         with pytest.raises(ValueError, match="timeout must be at least 1 second"):
             job.await_complete(timeout=0)
+
+    def test_get_result(self, batch_client: Mock):
+        job = BatchJob(batch_client, "mock-job-id")
+        result = job.get_result()
+        assert result.status == BatchJobStatus.FAILED
+
+    def test_get_status(self, batch_client: Mock):
+        job = BatchJob(batch_client, "mock-job-id")
+        status = job.get_status()
+        assert status == BatchJobStatus.FAILED
+
+    def test_await_complete(self, batch_client: Mock):
+        job = BatchJob(batch_client, "mock-job-id")
+        result = job.await_complete()
+        assert result.status == BatchJobStatus.FAILED


### PR DESCRIPTION
`get_status` and `get_result` methods for the `BatchJob` object. These are just convenience methods as this functionality is already available on the client.