### PR TITLE
Add facemesh support to streaming client

### DIFF
--- a/hume/_common/config/__init__.py
+++ b/hume/_common/config/__init__.py
@@ -1,6 +1,7 @@
 """Module init."""
 from hume._common.config.burst_config import BurstConfig
 from hume._common.config.face_config import FaceConfig
+from hume._common.config.facemesh_config import FacemeshConfig
 from hume._common.config.language_config import LanguageConfig
 from hume._common.config.job_config_base import JobConfigBase
 from hume._common.config.prosody_config import ProsodyConfig
@@ -8,6 +9,7 @@ from hume._common.config.prosody_config import ProsodyConfig
 __all__ = [
     "BurstConfig",
     "FaceConfig",
+    "FacemeshConfig",
     "LanguageConfig",
     "JobConfigBase",
     "ProsodyConfig",

--- a/hume/_common/config/config_utils.py
+++ b/hume/_common/config/config_utils.py
@@ -2,7 +2,7 @@
 from typing import Type
 
 from hume._common.model_type import ModelType
-from hume._common.config import BurstConfig, FaceConfig, LanguageConfig, JobConfigBase, ProsodyConfig
+from hume._common.config import BurstConfig, FaceConfig, FacemeshConfig, LanguageConfig, JobConfigBase, ProsodyConfig
 from hume._common.hume_client_error import HumeClientError
 
 
@@ -19,6 +19,8 @@ def config_from_model_type(model_type: ModelType) -> Type[JobConfigBase]:
         return BurstConfig
     if model_type == ModelType.FACE:
         return FaceConfig
+    if model_type == ModelType.FACEMESH:
+        return FacemeshConfig
     if model_type == ModelType.LANGUAGE:
         return LanguageConfig
     if model_type == ModelType.PROSODY:

--- a/hume/_common/config/facemesh_config.py
+++ b/hume/_common/config/facemesh_config.py
@@ -1,0 +1,38 @@
+"""Configuration for the facial expression model."""
+from typing import Any, Dict
+
+from hume._common.config.job_config_base import JobConfigBase
+from hume._common.model_type import ModelType
+
+
+class FacemeshConfig(JobConfigBase["FacemeshConfig"]):
+    """Configuration for the facemesh model."""
+
+    @classmethod
+    def get_model_type(cls) -> ModelType:
+        """Get the configuration model type.
+
+        Returns:
+            ModelType: Model type.
+        """
+        return ModelType.FACEMESH
+
+    def serialize(self) -> Dict[str, Any]:
+        """Serialize `FacemeshConfig` to dictionary.
+
+        Returns:
+            Dict[str, Any]: Serialized `FacemeshConfig` object.
+        """
+        return {}
+
+    @classmethod
+    def deserialize(cls, request_dict: Dict[str, Any]) -> "FacemeshConfig":
+        """Deserialize `FacemeshConfig` from request JSON.
+
+        Args:
+            request_dict (Dict[str, Any]): Request JSON data.
+
+        Returns:
+            FacemeshConfig: Deserialized `FacemeshConfig` object.
+        """
+        return cls()

--- a/hume/_common/model_type.py
+++ b/hume/_common/model_type.py
@@ -7,6 +7,7 @@ class ModelType(Enum):
 
     BURST = "burst"
     FACE = "face"
+    FACEMESH = "facemesh"
     LANGUAGE = "language"
     PROSODY = "prosody"
 

--- a/hume/_stream/stream_socket.py
+++ b/hume/_stream/stream_socket.py
@@ -163,13 +163,16 @@ class StreamSocket:
                 raise HumeClientError(f"Socket configured with {config_type}. "
                                       "send_facemesh is only supported when using a `FacemeshConfig`")
 
-        if len(landmarks) > self._FACE_LIMIT:
+        n_faces = len(landmarks)
+        if n_faces > self._FACE_LIMIT:
             raise HumeClientError("Number of faces sent in facemesh payload was greater "
-                                  f"than the limit of {self._FACE_LIMIT}.")
-        if len(landmarks) == 0:
+                                  f"than the limit of {self._FACE_LIMIT}, found {n_faces}.")
+        if n_faces == 0:
             raise HumeClientError("No faces sent in facemesh payload.")
-        if len(landmarks[0]) != self._N_LANDMARKS:
-            raise HumeClientError(f"Number of MediaPipe landmarks must be exactly {self._N_LANDMARKS}.")
+        n_landmarks = len(landmarks[0])
+        if n_landmarks != self._N_LANDMARKS:
+            raise HumeClientError(f"Number of MediaPipe landmarks must be exactly {self._N_LANDMARKS}, "
+                                  f"found {n_landmarks}.")
         if len(landmarks[0][0]) != self._N_SPATIAL:
             raise HumeClientError("Invalid facemesh payload detected. "
                                   "Each facemesh landmark should be an (x, y, z) point.")

--- a/hume/_stream/stream_socket.py
+++ b/hume/_stream/stream_socket.py
@@ -159,6 +159,20 @@ class StreamSocket:
                 raise HumeClientError(f"Socket configured with {config_type}. "
                                       "send_facemesh is only supported when using a `FacemeshConfig`")
 
+        FACE_LIMIT = 100
+        N_LANDMARKS = 478
+        N_SPATIAL = 3
+        if len(landmarks) > FACE_LIMIT:
+            raise HumeClientError("Number of faces sent in facemesh payload was greater "
+                                  f"than the limit of {FACE_LIMIT}")
+        if len(landmarks) == 0:
+            raise HumeClientError("No faces sent in facemesh payload")
+        if len(landmarks[0]) != N_LANDMARKS:
+            raise HumeClientError(f"Number of MediaPipe landmarks must be exactly {N_LANDMARKS}")
+        if len(landmarks[0]) != N_SPATIAL:
+            raise HumeClientError("Invalid facemesh payload detected. "
+                                  "Each facemesh landmark should be an (x, y, z) point.")
+
         landmarks_str = json.dumps(landmarks)
         bytes_data = base64.b64encode(landmarks_str.encode("utf-8"))
         return await self.send_bytes(bytes_data)

--- a/hume/_stream/stream_socket.py
+++ b/hume/_stream/stream_socket.py
@@ -10,7 +10,7 @@ try:
 except ModuleNotFoundError:
     HAS_WEBSOCKETS = False
 
-from hume._common.config import JobConfigBase, LanguageConfig
+from hume._common.config import FacemeshConfig, JobConfigBase, LanguageConfig
 from hume._common.hume_client_error import HumeClientError
 
 
@@ -133,4 +133,32 @@ class StreamSocket:
                                       "send_text is only supported when using a `LanguageConfig`")
 
         bytes_data = base64.b64encode(text.encode("utf-8"))
+        return await self.send_bytes(bytes_data)
+
+    async def send_facemesh(self, landmarks: List[List[List[float]]]) -> Any:
+        """Send text on the `StreamSocket`.
+
+        Note: This method is intended for use with a `FacemeshConfig`.
+            When the socket is configured for other modalities this method will fail.
+
+        Args:
+            landmarks (List[List[List[float]]]): List of landmark points for multiple faces.
+                The shape of this 3-dimensional list should be (n, 478, 3) where n is the number
+                of faces to be processed, 478 is the number of MediaPipe landmarks per face and 3
+                represents the (x, y, z) coordinates of each landmark.
+
+        Raises:
+            HumeClientError: If the socket is configured with a modality other than facemesh.
+
+        Returns:
+            Any: Predictions from the streaming API.
+        """
+        for config in self._configs:
+            if not isinstance(config, FacemeshConfig):
+                config_type = config.__class__.__name__
+                raise HumeClientError(f"Socket configured with {config_type}. "
+                                      "send_facemesh is only supported when using a `FacemeshConfig`")
+
+        landmarks_str = json.dumps(landmarks)
+        bytes_data = base64.b64encode(landmarks_str.encode("utf-8"))
         return await self.send_bytes(bytes_data)

--- a/hume/_stream/stream_socket.py
+++ b/hume/_stream/stream_socket.py
@@ -165,12 +165,12 @@ class StreamSocket:
 
         if len(landmarks) > self._FACE_LIMIT:
             raise HumeClientError("Number of faces sent in facemesh payload was greater "
-                                  f"than the limit of {self._FACE_LIMIT}")
+                                  f"than the limit of {self._FACE_LIMIT}.")
         if len(landmarks) == 0:
-            raise HumeClientError("No faces sent in facemesh payload")
+            raise HumeClientError("No faces sent in facemesh payload.")
         if len(landmarks[0]) != self._N_LANDMARKS:
-            raise HumeClientError(f"Number of MediaPipe landmarks must be exactly {self._N_LANDMARKS}")
-        if len(landmarks[0]) != self._N_SPATIAL:
+            raise HumeClientError(f"Number of MediaPipe landmarks must be exactly {self._N_LANDMARKS}.")
+        if len(landmarks[0][0]) != self._N_SPATIAL:
             raise HumeClientError("Invalid facemesh payload detected. "
                                   "Each facemesh landmark should be an (x, y, z) point.")
 

--- a/hume/_stream/stream_socket.py
+++ b/hume/_stream/stream_socket.py
@@ -17,6 +17,10 @@ from hume._common.hume_client_error import HumeClientError
 class StreamSocket:
     """Streaming socket connection."""
 
+    _FACE_LIMIT = 100
+    _N_LANDMARKS = 478
+    _N_SPATIAL = 3
+
     def __init__(
         self,
         protocol: "WebSocketClientProtocol",
@@ -159,17 +163,14 @@ class StreamSocket:
                 raise HumeClientError(f"Socket configured with {config_type}. "
                                       "send_facemesh is only supported when using a `FacemeshConfig`")
 
-        FACE_LIMIT = 100
-        N_LANDMARKS = 478
-        N_SPATIAL = 3
-        if len(landmarks) > FACE_LIMIT:
+        if len(landmarks) > self._FACE_LIMIT:
             raise HumeClientError("Number of faces sent in facemesh payload was greater "
-                                  f"than the limit of {FACE_LIMIT}")
+                                  f"than the limit of {self._FACE_LIMIT}")
         if len(landmarks) == 0:
             raise HumeClientError("No faces sent in facemesh payload")
-        if len(landmarks[0]) != N_LANDMARKS:
-            raise HumeClientError(f"Number of MediaPipe landmarks must be exactly {N_LANDMARKS}")
-        if len(landmarks[0]) != N_SPATIAL:
+        if len(landmarks[0]) != self._N_LANDMARKS:
+            raise HumeClientError(f"Number of MediaPipe landmarks must be exactly {self._N_LANDMARKS}")
+        if len(landmarks[0]) != self._N_SPATIAL:
             raise HumeClientError("Invalid facemesh payload detected. "
                                   "Each facemesh landmark should be an (x, y, z) point.")
 

--- a/hume/_stream/stream_socket.py
+++ b/hume/_stream/stream_socket.py
@@ -171,7 +171,7 @@ class StreamSocket:
             raise HumeClientError("No faces sent in facemesh payload.")
         n_landmarks = len(landmarks[0])
         if n_landmarks != self._N_LANDMARKS:
-            raise HumeClientError(f"Number of MediaPipe landmarks must be exactly {self._N_LANDMARKS}, "
+            raise HumeClientError(f"Number of MediaPipe landmarks per face must be exactly {self._N_LANDMARKS}, "
                                   f"found {n_landmarks}.")
         if len(landmarks[0][0]) != self._N_SPATIAL:
             raise HumeClientError("Invalid facemesh payload detected. "

--- a/hume/config/__init__.py
+++ b/hume/config/__init__.py
@@ -1,6 +1,7 @@
 """Module init."""
 from hume._common.config.burst_config import BurstConfig
 from hume._common.config.face_config import FaceConfig
+from hume._common.config.facemesh_config import FacemeshConfig
 from hume._common.config.language_config import LanguageConfig
 from hume._common.config.job_config_base import JobConfigBase
 from hume._common.config.prosody_config import ProsodyConfig
@@ -8,6 +9,7 @@ from hume._common.config.prosody_config import ProsodyConfig
 __all__ = [
     "BurstConfig",
     "FaceConfig",
+    "FacemeshConfig",
     "LanguageConfig",
     "JobConfigBase",
     "ProsodyConfig",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,12 +65,12 @@ build-backend = "poetry.core.masonry.api"
 requires = ["poetry-core>=1.0.0"]
 
 [tool.covcheck.group.unit.coverage]
-branch = 60.0
+branch = 63.0
 line = 84.0
 
 [tool.covcheck.group.service.coverage]
-branch = 66.0
-line = 90.0
+branch = 64.0
+line = 89.0
 
 [tool.flake8]
 ignore = ""           # Required to disable default ignores

--- a/tests/common/test_model_type.py
+++ b/tests/common/test_model_type.py
@@ -5,7 +5,7 @@ from hume import ModelType
 
 class TestModelType:
 
-    @pytest.mark.parametrize("model_type", ["face", "prosody", "burst", "language"])
+    @pytest.mark.parametrize("model_type", ["burst", "face", "facemesh", "language", "prosody"])
     def test_from_str(self, model_type):
         ModelType.from_str(model_type)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,4 +13,5 @@ def eval_data() -> EvalData:
         "burst-amusement-009": f"{base_url}/audio/burst-amusement-009.mp3",
         "prosody-horror-1051": f"{base_url}/audio/prosody-horror-1051.mp3",
         "text-happy-place": f"{base_url}/text/happy.txt",
+        "mesh-faces": f"{base_url}/landmarks/facelandmark_3face_test.json",
     }

--- a/tests/stream/conftest.py
+++ b/tests/stream/conftest.py
@@ -38,7 +38,7 @@ def mock_language_protocol():
 
     async def mock_send(message: str) -> None:
         assert json.loads(message) == {
-            "data": "bW9jay1tZWRpYS1maWxl",
+            "data": "bW9jay10ZXh0",
             "models": {
                 "language": {
                     "identify_speakers": None,
@@ -50,6 +50,30 @@ def mock_language_protocol():
     async def mock_recv() -> str:
         return json.dumps({
             "language": {
+                "predictions": "mock-predictions",
+            },
+        })
+
+    protocol = Mock()
+    protocol.send = mock_send
+    protocol.recv = mock_recv
+    return protocol
+
+
+@pytest.fixture(scope="function")
+def mock_facemesh_protocol():
+
+    async def mock_send(message: str) -> None:
+        assert json.loads(message) == {
+            "data": "Im1vY2stZmFjZW1lc2gi",
+            "models": {
+                "facemesh": {},
+            },
+        }
+
+    async def mock_recv() -> str:
+        return json.dumps({
+            "facemesh": {
                 "predictions": "mock-predictions",
             },
         })

--- a/tests/stream/conftest.py
+++ b/tests/stream/conftest.py
@@ -64,8 +64,9 @@ def mock_language_protocol():
 def mock_facemesh_protocol():
 
     async def mock_send(message: str) -> None:
-        assert json.loads(message) == {
-            "data": "Im1vY2stZmFjZW1lc2gi",
+        message_json = json.loads(message)
+        assert message_json == {
+            "data": message_json["data"],
             "models": {
                 "facemesh": {},
             },

--- a/tests/stream/test_stream_client_service.py
+++ b/tests/stream/test_stream_client_service.py
@@ -51,7 +51,7 @@ class TestHumeStreamClientService:
             assert predictions is not None
 
     async def test_send_facemesh(self, stream_client: HumeStreamClient):
-        meshes = [[[0, 0, 0]] * 475]
+        meshes = [[[0, 0, 0]] * 478]
         configs = [FacemeshConfig()]
         async with stream_client.connect(configs) as websocket:
             predictions = await websocket.send_facemesh(meshes)

--- a/tests/stream/test_stream_client_service.py
+++ b/tests/stream/test_stream_client_service.py
@@ -7,7 +7,7 @@ import pytest
 from pytest import TempPathFactory
 
 from hume import HumeStreamClient, HumeClientError
-from hume.config import FaceConfig, LanguageConfig
+from hume.config import FaceConfig, FacemeshConfig, LanguageConfig
 
 EvalData = Dict[str, str]
 
@@ -48,6 +48,13 @@ class TestHumeStreamClientService:
         configs = [LanguageConfig()]
         async with stream_client.connect(configs) as websocket:
             predictions = await websocket.send_text(sample_text)
+            assert predictions is not None
+
+    async def test_send_facemesh(self, stream_client: HumeStreamClient):
+        meshes = [[[0, 0, 0]] * 475]
+        configs = [FacemeshConfig()]
+        async with stream_client.connect(configs) as websocket:
+            predictions = await websocket.send_facemesh(meshes)
             assert predictions is not None
 
     async def test_invalid_api_key(self):

--- a/tests/stream/test_stream_socket.py
+++ b/tests/stream/test_stream_socket.py
@@ -86,7 +86,7 @@ class TestStreamSocket:
         with pytest.raises(HumeClientError, match=re.escape(message)):
             await socket.send_facemesh([0] * 150)
 
-        message = "Number of MediaPipe landmarks must be exactly 478, found 474."
+        message = "Number of MediaPipe landmarks per face must be exactly 478, found 474."
         with pytest.raises(HumeClientError, match=re.escape(message)):
             await socket.send_facemesh([[[0, 0, 0]] * 474])
 

--- a/tests/stream/test_stream_socket.py
+++ b/tests/stream/test_stream_socket.py
@@ -4,7 +4,7 @@ import pytest
 from pytest import TempPathFactory
 
 from hume import HumeClientError, StreamSocket
-from hume.config import FaceConfig, LanguageConfig, ProsodyConfig
+from hume.config import FaceConfig, FacemeshConfig, LanguageConfig, ProsodyConfig
 
 
 @pytest.mark.asyncio
@@ -41,7 +41,7 @@ class TestStreamSocket:
         configs = [LanguageConfig()]
         socket = StreamSocket(mock_language_protocol, configs)
 
-        sample_text = "mock-media-file"
+        sample_text = "mock-text"
         result = await socket.send_text(sample_text)
         assert result["language"]["predictions"] == "mock-predictions"
 
@@ -49,8 +49,26 @@ class TestStreamSocket:
         configs = [ProsodyConfig()]
         socket = StreamSocket(mock_language_protocol, configs)
 
-        sample_text = "mock-media-file"
+        sample_text = "mock-text"
         message = ("Socket configured with ProsodyConfig. "
                    "send_text is only supported when using a `LanguageConfig`")
         with pytest.raises(HumeClientError, match=message):
             await socket.send_text(sample_text)
+
+    async def test_send_facemesh(self, mock_facemesh_protocol: Mock):
+        configs = [FacemeshConfig()]
+        socket = StreamSocket(mock_facemesh_protocol, configs)
+
+        sample_facemesh = "mock-facemesh"
+        result = await socket.send_facemesh(sample_facemesh)
+        assert result["facemesh"]["predictions"] == "mock-predictions"
+
+    async def test_send_facemesh_not_facemesh(self, mock_language_protocol: Mock):
+        configs = [ProsodyConfig()]
+        socket = StreamSocket(mock_language_protocol, configs)
+
+        sample_facemesh = "mock-facemesh"
+        message = ("Socket configured with ProsodyConfig. "
+                   "send_facemesh is only supported when using a `FacemeshConfig`")
+        with pytest.raises(HumeClientError, match=message):
+            await socket.send_facemesh(sample_facemesh)

--- a/tests/stream/test_stream_socket.py
+++ b/tests/stream/test_stream_socket.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import Mock
 
 import pytest
@@ -78,17 +79,17 @@ class TestStreamSocket:
         socket = StreamSocket(mock_facemesh_protocol, configs)
 
         message = "No faces sent in facemesh payload."
-        with pytest.raises(HumeClientError, match=message):
+        with pytest.raises(HumeClientError, match=re.escape(message)):
             await socket.send_facemesh([])
 
-        message = "Number of faces sent in facemesh payload was greater than the limit of 100."
-        with pytest.raises(HumeClientError, match=message):
+        message = "Number of faces sent in facemesh payload was greater than the limit of 100, found 150."
+        with pytest.raises(HumeClientError, match=re.escape(message)):
             await socket.send_facemesh([0] * 150)
 
-        message = "Number of MediaPipe landmarks must be exactly 478."
-        with pytest.raises(HumeClientError, match=message):
+        message = "Number of MediaPipe landmarks must be exactly 478, found 474."
+        with pytest.raises(HumeClientError, match=re.escape(message)):
             await socket.send_facemesh([[[0, 0, 0]] * 474])
 
-        message = r"Invalid facemesh payload detected. Each facemesh landmark should be an \(x, y, z\) point."
-        with pytest.raises(HumeClientError, match=message):
+        message = "Invalid facemesh payload detected. Each facemesh landmark should be an (x, y, z) point."
+        with pytest.raises(HumeClientError, match=re.escape(message)):
             await socket.send_facemesh([[[0, 0]] * 478])


### PR DESCRIPTION
Adds support for the facemesh streaming API. Incudes a `FacemeshConfig` and also the convenience method `send_facemesh` on the `StreamSocket` which is only supported when sending a `FacemeshConfig`.