### PR TITLE
Send client headers to API

### DIFF
--- a/hume/_batch/hume_batch_client.py
+++ b/hume/_batch/hume_batch_client.py
@@ -1,5 +1,4 @@
 """Batch API client."""
-import importlib.metadata
 import json
 import logging
 from typing import Any, Dict, List, Optional
@@ -207,17 +206,11 @@ class HumeBatchClient(ClientBase):
         endpoint = (f"{self._api_http_base_url}/{self._api_version}/{ApiType.BATCH.value}/jobs"
                     f"?apikey={self._api_key}")
 
-        package_version = importlib.metadata.version("hume")
-        headers = {
-            "X-Hume-Client-Name": "python-sdk",
-            "X-Hume-Client-Version": package_version,
-        }
-
         response = requests.post(
             endpoint,
             json=request_body,
             timeout=self._DEFAULT_API_TIMEOUT,
-            headers=headers,
+            headers=self._get_client_headers(),
         )
 
         try:

--- a/hume/_batch/hume_batch_client.py
+++ b/hume/_batch/hume_batch_client.py
@@ -1,4 +1,5 @@
 """Batch API client."""
+import importlib.metadata
 import json
 import logging
 from typing import Any, Dict, List, Optional
@@ -205,7 +206,19 @@ class HumeBatchClient(ClientBase):
         """
         endpoint = (f"{self._api_http_base_url}/{self._api_version}/{ApiType.BATCH.value}/jobs"
                     f"?apikey={self._api_key}")
-        response = requests.post(endpoint, json=request_body, timeout=self._DEFAULT_API_TIMEOUT)
+
+        package_version = importlib.metadata.version("hume")
+        headers = {
+            "X-Hume-Client-Name": "python-sdk",
+            "X-Hume-Client-Version": package_version,
+        }
+
+        response = requests.post(
+            endpoint,
+            json=request_body,
+            timeout=self._DEFAULT_API_TIMEOUT,
+            headers=headers,
+        )
 
         try:
             body = response.json()

--- a/hume/_common/client_base.py
+++ b/hume/_common/client_base.py
@@ -1,6 +1,7 @@
 """Base class for Hume clients."""
-from typing import Optional
 from abc import ABC
+from typing import Dict, Optional
+import importlib.metadata
 
 
 class ClientBase(ABC):
@@ -25,3 +26,10 @@ class ClientBase(ABC):
         self._api_version = _api_version
         self._api_http_base_url = self._HTTP_BASE_URL if _api_http_base_url is None else _api_http_base_url
         self._api_ws_base_uri = self._WS_BASE_URI if _api_ws_base_uri is None else _api_ws_base_uri
+
+    def _get_client_headers(self) -> Dict[str, str]:
+        package_version = importlib.metadata.version("hume")
+        return {
+            "X-Hume-Client-Name": "python-sdk",
+            "X-Hume-Client-Version": package_version,
+        }

--- a/hume/_stream/hume_stream_client.py
+++ b/hume/_stream/hume_stream_client.py
@@ -1,5 +1,4 @@
 """Streaming API client."""
-import importlib.metadata
 import logging
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, List
@@ -66,15 +65,10 @@ class HumeStreamClient(ClientBase):
         uri = (f"{self._api_ws_base_uri}/{self._api_version}/{ApiType.STREAM.value}/multi"
                f"?apikey={self._api_key}")
 
-        package_version = importlib.metadata.version("hume")
-        headers = {
-            "X-Hume-Client-Name": "python-sdk",
-            "X-Hume-Client-Version": package_version,
-        }
-
         try:
             # pylint: disable=no-member
-            async with websockets.connect(uri, extra_headers=headers) as protocol:  # type: ignore[attr-defined]
+            async with websockets.connect(  # type: ignore[attr-defined]
+                    uri, extra_headers=self._get_client_headers()) as protocol:
                 yield StreamSocket(protocol, configs)
         except websockets.exceptions.InvalidStatusCode as exc:
             message = "Client initialized with invalid API key"

--- a/hume/_stream/hume_stream_client.py
+++ b/hume/_stream/hume_stream_client.py
@@ -1,4 +1,5 @@
 """Streaming API client."""
+import importlib.metadata
 import logging
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, List
@@ -65,9 +66,15 @@ class HumeStreamClient(ClientBase):
         uri = (f"{self._api_ws_base_uri}/{self._api_version}/{ApiType.STREAM.value}/multi"
                f"?apikey={self._api_key}")
 
+        package_version = importlib.metadata.version("hume")
+        headers = {
+            "X-Hume-Client-Name": "python-sdk",
+            "X-Hume-Client-Version": package_version,
+        }
+
         try:
             # pylint: disable=no-member
-            async with websockets.connect(uri) as protocol:  # type: ignore[attr-defined]
+            async with websockets.connect(uri, extra_headers=headers) as protocol:  # type: ignore[attr-defined]
                 yield StreamSocket(protocol, configs)
         except websockets.exceptions.InvalidStatusCode as exc:
             message = "Client initialized with invalid API key"

--- a/tests/stream/test_stream_client.py
+++ b/tests/stream/test_stream_client.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from unittest.mock import Mock
+from typing import Dict, Optional
 
 import pytest
 import websockets
@@ -9,8 +10,11 @@ from hume import HumeStreamClient, StreamSocket
 from hume.config import FaceConfig
 
 
-def mock_connect(uri: str):
+def mock_connect(uri: str, extra_headers: Optional[Dict[str, str]] = None):
     assert uri == "wss://api.hume.ai/v0/stream/multi?apikey=0000-0000-0000-0000"
+    assert isinstance(extra_headers, dict)
+    assert extra_headers.get("X-Hume-Client-Name") == "python-sdk"
+    assert isinstance(extra_headers.get("X-Hume-Client-Version"), str)
 
     @asynccontextmanager
     async def mock_connection() -> Mock:


### PR DESCRIPTION
Sets `X-Hume-Client-Name` and `X-Hume-Client-Version` headers on both streaming and batch clients.