### PR TITLE
Expose timeout parameters on API clients

### DIFF
--- a/hume/_batch/hume_batch_client.py
+++ b/hume/_batch/hume_batch_client.py
@@ -40,14 +40,13 @@ class HumeBatchClient(ClientBase):
         ```
     """
 
-    _DEFAULT_API_TIMEOUT = 10
-
-    def __init__(self, api_key: str, *args: Any, **kwargs: Any):
+    def __init__(self, api_key: str, *args: Any, timeout: int = 10, **kwargs: Any):
         """Construct a HumeBatchClient.
 
         Args:
             api_key (str): Hume API key.
         """
+        self._timeout = timeout
         super().__init__(api_key, *args, **kwargs)
 
     @classmethod
@@ -113,7 +112,7 @@ class HumeBatchClient(ClientBase):
         endpoint = self._construct_endpoint(f"jobs/{job_id}")
         response = requests.get(
             endpoint,
-            timeout=self._DEFAULT_API_TIMEOUT,
+            timeout=self._timeout,
             headers=self._get_client_headers(),
         )
 
@@ -143,7 +142,7 @@ class HumeBatchClient(ClientBase):
         endpoint = self._construct_endpoint(f"jobs/{job_id}/predictions")
         response = requests.get(
             endpoint,
-            timeout=self._DEFAULT_API_TIMEOUT,
+            timeout=self._timeout,
             headers=self._get_client_headers(),
         )
 
@@ -174,7 +173,7 @@ class HumeBatchClient(ClientBase):
         endpoint = self._construct_endpoint(f"jobs/{job_id}/artifacts")
         response = requests.get(
             endpoint,
-            timeout=self._DEFAULT_API_TIMEOUT,
+            timeout=self._timeout,
             headers=self._get_client_headers(),
         )
 
@@ -228,7 +227,7 @@ class HumeBatchClient(ClientBase):
             response = requests.post(
                 endpoint,
                 json=request_body,
-                timeout=self._DEFAULT_API_TIMEOUT,
+                timeout=self._timeout,
                 headers=self._get_client_headers(),
             )
         else:
@@ -236,7 +235,7 @@ class HumeBatchClient(ClientBase):
             post_files.append(("json", json.dumps(request_body).encode("utf-8")))
             response = requests.post(
                 endpoint,
-                timeout=self._DEFAULT_API_TIMEOUT,
+                timeout=self._timeout,
                 headers=self._get_client_headers(),
                 files=post_files,
             )

--- a/hume/_stream/hume_stream_client.py
+++ b/hume/_stream/hume_stream_client.py
@@ -37,8 +37,6 @@ class HumeStreamClient(ClientBase):
         ```
     """
 
-    _DEFAULT_API_TIMEOUT = 10
-
     def __init__(self, api_key: str, *args: Any, **kwargs: Any):
         """Construct a HumeStreamClient.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ license = "Proprietary"
 name = "hume"
 readme = "README.md"
 repository = "https://github.com/HumeAI/hume-python-sdk"
-version = "0.3.3"
+version = "0.3.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4"

--- a/tests/batch/test_hume_batch_client.py
+++ b/tests/batch/test_hume_batch_client.py
@@ -11,7 +11,7 @@ from hume.models.config import BurstConfig, FaceConfig, LanguageConfig, ProsodyC
 def batch_client(monkeypatch: MonkeyPatch) -> HumeBatchClient:
     mock_submit_request = MagicMock(return_value="temp-job-value")
     monkeypatch.setattr(HumeBatchClient, "_submit_job", mock_submit_request)
-    client = HumeBatchClient("0000-0000-0000-0000")
+    client = HumeBatchClient("0000-0000-0000-0000", timeout=15)
     mock_submit_request.return_value = BatchJob(client, "mock-job-id")
     return client
 


### PR DESCRIPTION
Allow users of `HumeBatchClient` and `HumeStreamClient` to increase HTTP request timeouts and WebSocket connection timeouts.