### PR TITLE
Pass filename when uploading local files with HumeBatchClient

### DIFF
--- a/hume/_batch/hume_batch_client.py
+++ b/hume/_batch/hume_batch_client.py
@@ -272,8 +272,8 @@ class HumeBatchClient(ClientBase):
     def _get_multipart_form_data(
         self,
         request_body: Any,
-        filepaths: Optional[List[Union[str, Path]]],
-    ) -> Tuple[str, Tuple[str, bytes]]:
+        filepaths: List[Union[str, Path]],
+    ) -> List[Tuple[str, Union[bytes, Tuple[str, bytes]]]]:
         """Convert a list of filepaths into a list of multipart form data.
 
         Multipart form data allows the client to attach files to the POST request,
@@ -281,12 +281,13 @@ class HumeBatchClient(ClientBase):
 
         Args:
             request_body (Any): JSON request body to be passed to the batch API.
-            filepaths (Optional[List[Union[str, Path]]]): List of paths to files on the local disk to be processed.
+            filepaths (List[Union[str, Path]]): List of paths to files on the local disk to be processed.
 
         Returns:
-            Tuple[str, Tuple[str, bytes]]: A list of tuples representing the multipart form data for the POST request.
+            List[Tuple[str, Union[bytes, Tuple[str, bytes]]]]: A list of tuples representing
+                the multipart form data for the POST request.
         """
-        form_data = []
+        form_data: List[Tuple[str, Union[bytes, Tuple[str, bytes]]]] = []
         for filepath in filepaths:
             path = Path(filepath)
             post_file = ("file", (path.name, path.read_bytes()))

--- a/hume/_batch/hume_batch_client.py
+++ b/hume/_batch/hume_batch_client.py
@@ -283,16 +283,12 @@ class HumeBatchClient(ClientBase):
             request_body (Any): JSON request body to be passed to the batch API.
             filepaths (Optional[List[Union[str, Path]]]): List of paths to files on the local disk to be processed.
 
-        Raises:
-            HumeClientException: If the batch job fails to start.
-
         Returns:
-            BatchJob: A `BatchJob` that wraps the batch computation.
+            Tuple[str, Tuple[str, bytes]]: A list of tuples representing the multipart form data for the POST request.
         """
         form_data = []
         for filepath in filepaths:
             path = Path(filepath)
-            # post_file = ("file", path.read_bytes())
             post_file = ("file", (path.name, path.read_bytes()))
             form_data.append(post_file)
 

--- a/hume/_batch/hume_batch_client.py
+++ b/hume/_batch/hume_batch_client.py
@@ -1,9 +1,9 @@
 """Batch API client."""
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
-import requests
+from requests import Session
 
 from hume._batch.batch_job import BatchJob
 from hume._batch.batch_job_details import BatchJobDetails
@@ -55,6 +55,7 @@ class HumeBatchClient(ClientBase):
             timeout (int): Time in seconds before canceling long-running Hume API requests.
         """
         self._timeout = timeout
+        self._session = Session()
         super().__init__(api_key, *args, **kwargs)
 
     @classmethod
@@ -118,7 +119,7 @@ class HumeBatchClient(ClientBase):
             BatchJobDetails: Batch job details.
         """
         endpoint = self._construct_endpoint(f"jobs/{job_id}")
-        response = requests.get(
+        response = self._session.get(
             endpoint,
             timeout=self._timeout,
             headers=self._get_client_headers(),
@@ -148,7 +149,7 @@ class HumeBatchClient(ClientBase):
             Any: Batch job predictions.
         """
         endpoint = self._construct_endpoint(f"jobs/{job_id}/predictions")
-        response = requests.get(
+        response = self._session.get(
             endpoint,
             timeout=self._timeout,
             headers=self._get_client_headers(),
@@ -179,7 +180,7 @@ class HumeBatchClient(ClientBase):
             Any: Batch job artifacts.
         """
         endpoint = self._construct_endpoint(f"jobs/{job_id}/artifacts")
-        response = requests.get(
+        response = self._session.get(
             endpoint,
             timeout=self._timeout,
             headers=self._get_client_headers(),
@@ -212,7 +213,7 @@ class HumeBatchClient(ClientBase):
     def _submit_job(
         self,
         request_body: Any,
-        files: Optional[List[Union[str, Path]]],
+        filepaths: Optional[List[Union[str, Path]]],
     ) -> BatchJob:
         """Start a job for batch processing by passing a JSON request body.
 
@@ -221,7 +222,7 @@ class HumeBatchClient(ClientBase):
 
         Args:
             request_body (Any): JSON request body to be passed to the batch API.
-            files (Optional[List[Union[str, Path]]]): List of paths to files on the local disk to be processed.
+            filepaths (Optional[List[Union[str, Path]]]): List of paths to files on the local disk to be processed.
 
         Raises:
             HumeClientException: If the batch job fails to start.
@@ -231,21 +232,20 @@ class HumeBatchClient(ClientBase):
         """
         endpoint = self._construct_endpoint("jobs")
 
-        if files is None:
-            response = requests.post(
+        if filepaths is None:
+            response = self._session.post(
                 endpoint,
                 json=request_body,
                 timeout=self._timeout,
                 headers=self._get_client_headers(),
             )
         else:
-            post_files = [("file", Path(path).read_bytes()) for path in files]
-            post_files.append(("json", json.dumps(request_body).encode("utf-8")))
-            response = requests.post(
+            form_data = self._get_multipart_form_data(request_body, filepaths)
+            response = self._session.post(
                 endpoint,
                 timeout=self._timeout,
                 headers=self._get_client_headers(),
-                files=post_files,
+                files=form_data,
             )
 
         try:
@@ -268,3 +268,32 @@ class HumeBatchClient(ClientBase):
             raise HumeClientException(f"Unexpected error when starting batch job: {body}")
 
         return BatchJob(self, body["job_id"])
+
+    def _get_multipart_form_data(
+        self,
+        request_body: Any,
+        filepaths: Optional[List[Union[str, Path]]],
+    ) -> Tuple[str, Tuple[str, bytes]]:
+        """Convert a list of filepaths into a list of multipart form data.
+
+        Multipart form data allows the client to attach files to the POST request,
+        including both the raw file bytes and the filename.
+
+        Args:
+            request_body (Any): JSON request body to be passed to the batch API.
+            filepaths (Optional[List[Union[str, Path]]]): List of paths to files on the local disk to be processed.
+
+        Raises:
+            HumeClientException: If the batch job fails to start.
+
+        Returns:
+            BatchJob: A `BatchJob` that wraps the batch computation.
+        """
+        form_data = []
+        for filepath in filepaths:
+            path = Path(filepath)
+            post_file = ("file", (path.name, (path.read_bytes())))
+            form_data.append(post_file)
+
+        form_data.append(("json", json.dumps(request_body).encode("utf-8")))
+        return form_data

--- a/hume/_batch/hume_batch_client.py
+++ b/hume/_batch/hume_batch_client.py
@@ -292,7 +292,8 @@ class HumeBatchClient(ClientBase):
         form_data = []
         for filepath in filepaths:
             path = Path(filepath)
-            post_file = ("file", (path.name, (path.read_bytes())))
+            # post_file = ("file", path.read_bytes())
+            post_file = ("file", (path.name, path.read_bytes()))
             form_data.append(post_file)
 
         form_data.append(("json", json.dumps(request_body).encode("utf-8")))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ license = "Proprietary"
 name = "hume"
 readme = "README.md"
 repository = "https://github.com/HumeAI/hume-python-sdk"
-version = "0.3.4"
+version = "0.3.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4"

--- a/tests/batch/test_service_hume_batch_client.py
+++ b/tests/batch/test_service_hume_batch_client.py
@@ -121,8 +121,8 @@ class TestServiceHumeBatchClient:
             rehydrated_job = BatchJob(invalid_client, job.id)
             rehydrated_job.await_complete(10)
 
-    def test_local_file_upload(self, eval_data: EvalData, batch_client: HumeBatchClient,
-                               tmp_path_factory: TempPathFactory):
+    def test_local_file_upload_simple(self, eval_data: EvalData, batch_client: HumeBatchClient,
+                                      tmp_path_factory: TempPathFactory):
         data_url = eval_data["image-obama-face"]
         data_filepath = tmp_path_factory.mktemp("data-dir") / "obama.png"
         urlretrieve(data_url, data_filepath)
@@ -130,6 +130,9 @@ class TestServiceHumeBatchClient:
         job_files_dirpath = tmp_path_factory.mktemp("job-files")
         job = batch_client.submit_job([], [config], files=[data_filepath])
         self.check_job(job, config, FaceConfig, job_files_dirpath, complete_config=False)
+
+        predictions = job.get_predictions()
+        assert predictions[0]["source"]["filename"] == "obama.png"
 
     def test_local_file_upload_configure(self, eval_data: EvalData, batch_client: HumeBatchClient,
                                          tmp_path_factory: TempPathFactory):


### PR DESCRIPTION
Before this change all local files uploaded in a batch job would have predictions returned with the filename "file". After this change the actual filename of the local file is used to disambiguate multiple file predictions.