### PR TITLE
Payload-level model configuration for HumeStreamClient

### DIFF
--- a/hume/_stream/stream_socket.py
+++ b/hume/_stream/stream_socket.py
@@ -32,7 +32,7 @@ class StreamSocket:
 
         Args:
             protocol (WebSocketClientProtocol): Protocol instance from websockets library.
-            configs (List[ModelConfigBase]): List of model configurations.
+            configs (Optional[List[ModelConfigBase]]): List of model configurations.
             stream_window_ms (Optional[int]): Length of the sliding window in milliseconds to use when
                 aggregating media across streaming payloads within one websocket connection.
 
@@ -60,9 +60,9 @@ class StreamSocket:
 
         Args:
             filepath (Path): Path to media file to send on socket connection.
-            configs (List[ModelConfigBase]): List of model configurations.
+            configs (Optional[List[ModelConfigBase]]): List of model configurations.
                 If set these configurations will overwrite any configurations
-                set when initializing the StreamSocket.
+                set when initializing the `StreamSocket`.
 
         Returns:
             Any: Response from the streaming API.
@@ -83,9 +83,9 @@ class StreamSocket:
 
         Args:
             bytes_data (bytes): Raw bytes of media to send on socket connection.
-            configs (List[ModelConfigBase]): List of model configurations.
+            configs (Optional[List[ModelConfigBase]]): List of model configurations.
                 If set these configurations will overwrite any configurations
-                set when initializing the StreamSocket.
+                set when initializing the `StreamSocket`.
 
         Returns:
             Any: Response from the streaming API.
@@ -105,9 +105,9 @@ class StreamSocket:
 
         Args:
             text (str): Text to send to the language model.
-            configs (List[ModelConfigBase]): List of model configurations.
+            configs (Optional[List[ModelConfigBase]]): List of model configurations.
                 If set these configurations will overwrite any configurations
-                set when initializing the StreamSocket.
+                set when initializing the `StreamSocket`.
 
         Raises:
             HumeClientException: If the socket is configured with a modality other than language.
@@ -133,9 +133,9 @@ class StreamSocket:
                 The shape of this 3-dimensional list should be (n, 478, 3) where n is the number
                 of faces to be processed, 478 is the number of MediaPipe landmarks per face and 3
                 represents the (x, y, z) coordinates of each landmark.
-            configs (List[ModelConfigBase]): List of model configurations.
+            configs (Optional[List[ModelConfigBase]]): List of model configurations.
                 If set these configurations will overwrite any configurations
-                set when initializing the StreamSocket.
+                set when initializing the `StreamSocket`.
 
         Raises:
             HumeClientException: If the socket is configured with a modality other than facemesh.

--- a/hume/_stream/stream_socket.py
+++ b/hume/_stream/stream_socket.py
@@ -51,20 +51,31 @@ class StreamSocket:
         # Serialize configs once for full lifetime of socket
         self._serialized_configs = serialize_configs(configs)
 
-    async def send_file(self, filepath: Union[str, Path]) -> Any:
+    async def send_file(
+        self,
+        filepath: Union[str, Path],
+        configs: Optional[List[ModelConfigBase]] = None,
+    ) -> Any:
         """Send a file on the `StreamSocket`.
 
         Args:
             filepath (Path): Path to media file to send on socket connection.
+            configs (List[ModelConfigBase]): List of model configurations.
+                If set these configurations will overwrite any configurations
+                set when initializing the StreamSocket.
 
         Returns:
             Any: Response from the streaming API.
         """
         with Path(filepath).open('rb') as f:
             bytes_data = base64.b64encode(f.read())
-            return await self.send_bytes(bytes_data)
+            return await self.send_bytes(bytes_data, configs=configs)
 
-    async def send_bytes(self, bytes_data: bytes) -> Any:
+    async def send_bytes(
+        self,
+        bytes_data: bytes,
+        configs: Optional[List[ModelConfigBase]] = None,
+    ) -> Any:
         """Send raw bytes on the `StreamSocket`.
 
         Note: Input should be base64 encoded bytes.
@@ -72,14 +83,21 @@ class StreamSocket:
 
         Args:
             bytes_data (bytes): Raw bytes of media to send on socket connection.
+            configs (List[ModelConfigBase]): List of model configurations.
+                If set these configurations will overwrite any configurations
+                set when initializing the StreamSocket.
 
         Returns:
             Any: Response from the streaming API.
         """
         bytes_str = bytes_data.decode("utf-8")
-        return await self._send_bytes_str(bytes_str)
+        return await self._send_str(bytes_str, raw_text=False, configs=configs)
 
-    async def send_text(self, text: str) -> Any:
+    async def send_text(
+        self,
+        text: str,
+        configs: Optional[List[ModelConfigBase]] = None,
+    ) -> Any:
         """Send text on the `StreamSocket`.
 
         Note: This method is intended for use with a `LanguageConfig`.
@@ -87,6 +105,9 @@ class StreamSocket:
 
         Args:
             text (str): Text to send to the language model.
+            configs (List[ModelConfigBase]): List of model configurations.
+                If set these configurations will overwrite any configurations
+                set when initializing the StreamSocket.
 
         Raises:
             HumeClientException: If the socket is configured with a modality other than language.
@@ -94,18 +115,14 @@ class StreamSocket:
         Returns:
             Any: Response from the streaming API.
         """
-        self._validate_configs_with_model_type(LanguageConfig, "send_text")
+        self._validate_configs_with_model_type(LanguageConfig, "send_text", configs=configs)
+        return await self._send_str(text, raw_text=True, configs=configs)
 
-        payload = {
-            "data": text,
-            "models": self._serialized_configs,
-            "raw_text": True,
-        }
-        if self._stream_window_ms is not None:
-            payload["stream_window_ms"] = self._stream_window_ms
-        return await self._send_payload(payload)
-
-    async def send_facemesh(self, landmarks: List[List[List[float]]]) -> Any:
+    async def send_facemesh(
+        self,
+        landmarks: List[List[List[float]]],
+        configs: Optional[List[ModelConfigBase]] = None,
+    ) -> Any:
         """Send facemesh landmarks on the `StreamSocket`.
 
         Note: This method is intended for use with a `FacemeshConfig`.
@@ -116,6 +133,9 @@ class StreamSocket:
                 The shape of this 3-dimensional list should be (n, 478, 3) where n is the number
                 of faces to be processed, 478 is the number of MediaPipe landmarks per face and 3
                 represents the (x, y, z) coordinates of each landmark.
+            configs (List[ModelConfigBase]): List of model configurations.
+                If set these configurations will overwrite any configurations
+                set when initializing the StreamSocket.
 
         Raises:
             HumeClientException: If the socket is configured with a modality other than facemesh.
@@ -123,7 +143,7 @@ class StreamSocket:
         Returns:
             Any: Response from the streaming API.
         """
-        self._validate_configs_with_model_type(FacemeshConfig, "send_facemesh")
+        self._validate_configs_with_model_type(FacemeshConfig, "send_facemesh", configs=configs)
 
         n_faces = len(landmarks)
         if n_faces > self._FACE_LIMIT:
@@ -141,7 +161,7 @@ class StreamSocket:
 
         landmarks_str = json.dumps(landmarks)
         bytes_data = base64.b64encode(landmarks_str.encode("utf-8"))
-        return await self.send_bytes(bytes_data)
+        return await self.send_bytes(bytes_data, configs=configs)
 
     async def reset_stream(self) -> Any:
         """Reset the streaming sliding window.
@@ -169,10 +189,21 @@ class StreamSocket:
         }
         return await self._send_payload(payload)
 
-    async def _send_bytes_str(self, bytes_str: str) -> Any:
+    async def _send_str(
+        self,
+        data: str,
+        *,
+        raw_text: bool,
+        configs: Optional[List[ModelConfigBase]] = None,
+    ) -> Any:
+        serialized_configs = self._serialized_configs
+        if configs is not None:
+            serialized_configs = serialize_configs(configs)
+
         payload: Dict[str, Any] = {
-            "data": bytes_str,
-            "models": self._serialized_configs,
+            "data": data,
+            "models": serialized_configs,
+            "raw_text": raw_text,
         }
         if self._stream_window_ms is not None:
             payload["stream_window_ms"] = self._stream_window_ms
@@ -197,10 +228,21 @@ class StreamSocket:
 
         return response
 
-    def _validate_configs_with_model_type(self, config_type: Any, method_name: str) -> None:
-        for config in self._configs:
+    def _validate_configs_with_model_type(
+        self,
+        config_type: Any,
+        method_name: str,
+        configs: Optional[List[ModelConfigBase]] = None,
+    ) -> None:
+        config_method = "Socket"
+        payload_configs = self._configs
+        if configs is not None:
+            config_method = "Payload"
+            payload_configs = configs
+
+        for config in payload_configs:
             if not isinstance(config, config_type):
                 config_name = config_type.__name__
                 invalid_config_name = config.__class__.__name__
-                raise HumeClientException(f"Socket configured with {invalid_config_name}. "
+                raise HumeClientException(f"{config_method} configured with {invalid_config_name}. "
                                           f"{method_name} is only supported when using a {config_name}.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ websockets = { version = "^10.3", optional = true }
 jupyter = { version = "^1.0.0", optional = true }
 pydub = { version = "^0.25.1", optional = true }
 
-
 [tool.poetry.dev-dependencies]
 covcheck = "^0.4.2"
 flake8 = "^6.0.0"

--- a/tests/stream/conftest.py
+++ b/tests/stream/conftest.py
@@ -15,6 +15,7 @@ def mock_face_protocol():
                     "identify_faces": True,
                 },
             },
+            "raw_text": False,
         }
 
     async def mock_recv() -> str:
@@ -65,6 +66,7 @@ def mock_facemesh_protocol():
             "models": {
                 "facemesh": {},
             },
+            "raw_text": False,
         }
 
     async def mock_recv() -> str:


### PR DESCRIPTION
This PR enables payload-level model configuration, which allows users of the `HumeStreamClient` to configure models independently for each WebSocket payload.
Payload-level configuration takes priority, overwriting the socket-level configuration.