### PR TITLE
BatchJob raise_on_failed flag

### DIFF
--- a/hume/_batch/batch_job_state.py
+++ b/hume/_batch/batch_job_state.py
@@ -15,7 +15,6 @@ class BatchJobState:
         started_timestamp_ms (Optional[int]): Time when job started.
         ended_timestamp_ms (Optional[int]): Time when job ended.
     """
-
     status: BatchJobStatus
     created_timestamp_ms: Optional[int]
     started_timestamp_ms: Optional[int]

--- a/hume/_batch/batch_job_state.py
+++ b/hume/_batch/batch_job_state.py
@@ -15,6 +15,7 @@ class BatchJobState:
         started_timestamp_ms (Optional[int]): Time when job started.
         ended_timestamp_ms (Optional[int]): Time when job ended.
     """
+
     status: BatchJobStatus
     created_timestamp_ms: Optional[int]
     started_timestamp_ms: Optional[int]

--- a/tests/batch/test_batch_job.py
+++ b/tests/batch/test_batch_job.py
@@ -6,6 +6,7 @@ import pytest
 from hume import BatchJob, BatchJobDetails, BatchJobState, BatchJobStatus
 from hume.models import ModelType
 from hume.models.config import FaceConfig
+from hume import HumeClientException
 
 
 @pytest.fixture(scope="function")
@@ -57,3 +58,9 @@ class TestBatchJob:
         job = BatchJob(batch_client, "mock-job-id")
         details = job.await_complete()
         assert details.state.status == BatchJobStatus.FAILED
+
+    def test_raise_on_failed(self, batch_client: Mock):
+        job = BatchJob(batch_client, "mock-job-id")
+        message = "BatchJob mock-job-id failed."
+        with pytest.raises(HumeClientException, match=re.escape(message)):
+            job.await_complete(raise_on_failed=True)


### PR DESCRIPTION
Adding support for `BatchJob.await_complete(raise_on_failed=True)`. This allows the user to be alerted when a job fails instead of having to manually check the job status after `await_complete()` returns.