### PR TITLE
Enable more configurations for FaceConfig + HumeStreamClient

### DIFF
--- a/hume/models/config/face_config.py
+++ b/hume/models/config/face_config.py
@@ -13,17 +13,14 @@ class FaceConfig(ModelConfigBase["FaceConfig"]):
     Args:
         fps_pred (Optional[float]): Number of frames per second to process. Other frames will be omitted
             from the response.
-            This configuration is only available for the batch API.
         prob_threshold (Optional[float]): Face detection probability threshold. Faces detected with a
             probability less than this threshold will be omitted from the response.
-            This configuration is only available for the batch API.
         identify_faces (Optional[bool]): Whether to return identifiers for faces across frames.
             If true, unique identifiers will be assigned to face bounding boxes to differentiate different faces.
             If false, all faces will be tagged with an "unknown" ID.
         min_face_size (Optional[float]): Minimum bounding box side length in pixels to treat as a face.
             Faces detected with a bounding box side length in pixels less than this threshold will be
             omitted from the response.
-            This configuration is only available for the batch API.
         save_faces (Optional[bool]): Whether to extract and save the detected faces to the artifacts
             directory included in the response.
             This configuration is only available for the batch API.


### PR DESCRIPTION
The streaming API supports more configurations now. These configurations were already available in the batch API, so this PR just updates docs.