### PR TITLE
Add support for Python 3.10 and 3.11, drop support for 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v2
@@ -87,10 +88,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Python 3.8 Setup
+      - name: Python 3.10 Setup
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Install Python dependencies
         shell: bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-Python versions 3.8 and 3.9 are supported
+Python versions 3.9, 3.10, and 3.11 are supported
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ license = "Proprietary"
 name = "hume"
 readme = "README.md"
 repository = "https://github.com/HumeAI/hume-python-sdk"
-version = "0.3.7"
+version = "0.4.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ authors = ["Hume AI Dev <dev@hume.ai>"]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
 ]
 description = "Hume AI Python Client"
 keywords = [


### PR DESCRIPTION
The hume package dependencies lower bound will still techincally allow the package to be installed with Python 3.8, but official support will be dropped in version 0.4.0. It is no longer recommended to use the hume package with Python 3.8. Python 3.10 and 3.11 will be officially supported now.