### PR TITLE
Support raw text input

### DIFF
--- a/hume/_batch/batch_job_details.py
+++ b/hume/_batch/batch_job_details.py
@@ -20,6 +20,7 @@ class BatchJobDetails:
         configs: Dict[ModelType, ModelConfigBase],
         urls: List[str],
         files: List[str],
+        text: List[str],
         state: BatchJobState,
         callback_url: Optional[str] = None,
         notify: bool = False,
@@ -30,6 +31,7 @@ class BatchJobDetails:
             configs (Dict[ModelType, ModelConfigBase]): Configurations for the `BatchJob`.
             urls (List[str]): URLs processed in the `BatchJob`.
             files (List[str]): Files processed in the `BatchJob`.
+            text (List[str]): Raw text processed in the `BatchJob`.
             state (BatchJobState): State of `BatchJob`.
             callback_url (Optional[str]): A URL to which a POST request is sent upon job completion.
             notify (bool): Whether an email notification should be sent upon job completion.
@@ -37,6 +39,7 @@ class BatchJobDetails:
         self.configs = configs
         self.urls = urls
         self.files = files
+        self.text = text
         self.state = state
         self.callback_url = callback_url
         self.notify = notify
@@ -64,6 +67,7 @@ class BatchJobDetails:
 
             urls = request["urls"]
             files = request["files"]
+            text = request["text"]
             callback_url = request["callback_url"]
             notify = request["notify"]
 
@@ -79,6 +83,7 @@ class BatchJobDetails:
                 configs=configs,
                 urls=urls,
                 files=files,
+                text=text,
                 state=state,
                 callback_url=callback_url,
                 notify=notify,

--- a/hume/_batch/batch_job_details.py
+++ b/hume/_batch/batch_job_details.py
@@ -31,7 +31,7 @@ class BatchJobDetails:
             configs (Dict[ModelType, ModelConfigBase]): Configurations for the `BatchJob`.
             urls (List[str]): URLs processed in the `BatchJob`.
             files (List[str]): Files processed in the `BatchJob`.
-            text (List[str]): Raw text processed in the `BatchJob`.
+            text (Optional[List[str]]): Raw text processed in the `BatchJob`.
             state (BatchJobState): State of `BatchJob`.
             callback_url (Optional[str]): A URL to which a POST request is sent upon job completion.
             notify (bool): Whether an email notification should be sent upon job completion.

--- a/hume/_batch/batch_job_details.py
+++ b/hume/_batch/batch_job_details.py
@@ -20,7 +20,7 @@ class BatchJobDetails:
         configs: Dict[ModelType, ModelConfigBase],
         urls: List[str],
         files: List[str],
-        text: List[str],
+        text: Optional[List[str]] = None,
         state: BatchJobState,
         callback_url: Optional[str] = None,
         notify: bool = False,

--- a/hume/_batch/hume_batch_client.py
+++ b/hume/_batch/hume_batch_client.py
@@ -82,6 +82,7 @@ class HumeBatchClient(ClientBase):
         self,
         urls: List[str],
         configs: List[ModelConfigBase],
+        text: Optional[List[str]] = None,
         transcription_config: Optional[TranscriptionConfig] = None,
         callback_url: Optional[str] = None,
         notify: Optional[bool] = None,
@@ -99,11 +100,12 @@ class HumeBatchClient(ClientBase):
             callback_url (Optional[str]): A URL to which a POST request will be sent upon job completion.
             notify (Optional[bool]): Wether an email notification should be sent upon job completion.
             files (Optional[List[Union[str, Path]]]): List of paths to files on the local disk to be processed.
+            text (Optional[List[str]]): List of strings (raw text) to be processed.
 
         Returns:
             BatchJob: The `BatchJob` representing the batch computation.
         """
-        request = self._construct_request(configs, urls, transcription_config, callback_url, notify)
+        request = self._construct_request(configs, urls, text, transcription_config, callback_url, notify)
         return self._submit_job(request, files)
 
     def get_job_details(self, job_id: str) -> BatchJobDetails:
@@ -194,6 +196,7 @@ class HumeBatchClient(ClientBase):
         cls,
         configs: List[ModelConfigBase],
         urls: List[str],
+        text: Optional[List[str]],
         transcription_config: Optional[TranscriptionConfig],
         callback_url: Optional[str],
         notify: Optional[bool],
@@ -202,6 +205,8 @@ class HumeBatchClient(ClientBase):
             "urls": urls,
             "models": serialize_configs(configs),
         }
+        if text is not None:
+            request["text"] = text
         if transcription_config is not None:
             request["transcription"] = transcription_config.to_dict()
         if callback_url is not None:

--- a/hume/_batch/hume_batch_client.py
+++ b/hume/_batch/hume_batch_client.py
@@ -82,11 +82,11 @@ class HumeBatchClient(ClientBase):
         self,
         urls: List[str],
         configs: List[ModelConfigBase],
-        text: Optional[List[str]] = None,
         transcription_config: Optional[TranscriptionConfig] = None,
         callback_url: Optional[str] = None,
         notify: Optional[bool] = None,
         files: Optional[List[Union[str, Path]]] = None,
+        text: Optional[List[str]] = None,
     ) -> BatchJob:
         """Submit a job for batch processing.
 

--- a/tests/batch/data/details-response-completed.json
+++ b/tests/batch/data/details-response-completed.json
@@ -10,6 +10,7 @@
     },
     "urls": ["https://storage.googleapis.com/hume-test-data/video/royal-opera-house.mp4"],
     "files": [],
+    "text": [],
     "callback_url": "https:/fake-callback",
     "notify": false
   },
@@ -18,5 +19,5 @@
     "created_timestamp_ms": 1660594810000,
     "started_timestamp_ms": 1660594812000,
     "ended_timestamp_ms": 1660594815000
-}
+  }
 }

--- a/tests/batch/data/details-response-failed.json
+++ b/tests/batch/data/details-response-failed.json
@@ -10,6 +10,7 @@
     },
     "urls": ["https://storage.googleapis.com/hume-test-data/image/obama.png"],
     "files": [],
+    "text": [],
     "callback_url": null,
     "notify": false
   },

--- a/tests/batch/data/details-response-queued.json
+++ b/tests/batch/data/details-response-queued.json
@@ -10,6 +10,7 @@
     },
     "urls": ["https://storage.googleapis.com/hume-test-data/video/royal-opera-house.mp4"],
     "files": [],
+    "text": [],
     "callback_url": null,
     "notify": false
   },

--- a/tests/batch/test_hume_batch_client.py
+++ b/tests/batch/test_hume_batch_client.py
@@ -93,6 +93,26 @@ class TestHumeBatchClient:
             None,
         )
 
+    def test_language_with_raw_text(self, batch_client: HumeBatchClient):
+        mock_text = "Test!"
+        config = LanguageConfig(granularity="word", identify_speakers=True)
+        job = batch_client.submit_job([], [config], text=[mock_text])
+        assert isinstance(job, BatchJob)
+        assert job.id == "mock-job-id"
+        batch_client._submit_job.assert_called_once_with(
+            {
+                "urls": [],
+                "models": {
+                    "language": {
+                        "granularity": "word",
+                        "identify_speakers": True,
+                    },
+                },
+                "text": [mock_text],
+            },
+            None,
+        )
+
     def test_get_job(self, batch_client: HumeBatchClient):
         job = batch_client.get_job("mock-job-id")
         assert job.id == "mock-job-id"

--- a/tests/batch/test_service_hume_batch_client.py
+++ b/tests/batch/test_service_hume_batch_client.py
@@ -142,9 +142,9 @@ class TestServiceHumeBatchClient:
         self.check_job(job, config, LanguageConfig, job_files_dirpath, complete_config=False)
 
         predictions = job.get_predictions()
-        languagePredictions = predictions[0]["results"]["predictions"][0]["models"]["language"]
+        language_predictions = predictions[0]["results"]["predictions"][0]["models"]["language"]
         assert predictions[0]["source"]["type"] == "text"
-        assert languagePredictions["grouped_predictions"][0]["predictions"][0]["text"] == "Test!"
+        assert language_predictions["grouped_predictions"][0]["predictions"][0]["text"] == "Test!"
 
     def test_local_file_upload_configure(self, eval_data: EvalData, batch_client: HumeBatchClient,
                                          tmp_path_factory: TempPathFactory):

--- a/tests/batch/test_service_hume_batch_client.py
+++ b/tests/batch/test_service_hume_batch_client.py
@@ -134,6 +134,18 @@ class TestServiceHumeBatchClient:
         predictions = job.get_predictions()
         assert predictions[0]["source"]["filename"] == "obama.png"
 
+    def test_data_as_raw_text(self, batch_client: HumeBatchClient, tmp_path_factory: TempPathFactory):
+        data_raw_text = "Test!"
+        config = LanguageConfig()
+        job_files_dirpath = tmp_path_factory.mktemp("job-files")
+        job = batch_client.submit_job([], [config], text=[data_raw_text])
+        self.check_job(job, config, LanguageConfig, job_files_dirpath, complete_config=False)
+
+        predictions = job.get_predictions()
+        languagePredictions = predictions[0]["results"]["predictions"][0]["models"]["language"]
+        assert predictions[0]["source"]["type"] == "text"
+        assert languagePredictions["grouped_predictions"][0]["predictions"][0]["text"] == "Test!"
+
     def test_local_file_upload_configure(self, eval_data: EvalData, batch_client: HumeBatchClient,
                                          tmp_path_factory: TempPathFactory):
         data_url = eval_data["text-happy-place"]


### PR DESCRIPTION
## Summary of Changes Made

In our most recent [Batch API release](https://dev.hume.ai/changelog/release-october-2023) we updated the Batch API to accept data as raw text for processing. The goal here is to add this same functionality to the Python SDK.

- added `text` parameter to `HumeBatchClient.submit_job` method to support passing data as raw text. 
- added unit test & e2e test in correspondence with the new parameter changes.