### PR TITLE
Add missing py.typed File for type-checkers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ name = "hume"
 readme = "README.md"
 repository = "https://github.com/HumeAI/hume-python-sdk"
 version = "0.5.1"
+include = [
+  "hume/py.typed",
+]
 
 [tool.poetry.dependencies]
 httpx = { extras = ["http2"], version = "^0.27.0" }


### PR DESCRIPTION
Since a `py.typed` file is missing, which [PEP 561](https://peps.python.org/pep-0561/) mandates is required to support type-checking, type-checkers such as Pyright will raise a warning when `hume` is imported. This PR adds this, removing such warnings.

Example:
![CleanShot 2024-05-23 at 18 21 38](https://github.com/HumeAI/hume-python-sdk/assets/41130755/138c10ce-77cb-4e7c-91df-668e0710bcad)
