### PR TITLE
Remove Unnecessary Generic Param

### DIFF
--- a/hume/models/config/burst_config.py
+++ b/hume/models/config/burst_config.py
@@ -7,7 +7,7 @@ from hume.models.config.model_config_base import ModelConfigBase
 
 
 @dataclass
-class BurstConfig(ModelConfigBase["BurstConfig"]):
+class BurstConfig(ModelConfigBase):
     """Configuration for the vocal burst model."""
 
     @classmethod

--- a/hume/models/config/face_config.py
+++ b/hume/models/config/face_config.py
@@ -8,7 +8,7 @@ from hume.models.config.model_config_base import ModelConfigBase
 
 
 @dataclass
-class FaceConfig(ModelConfigBase["FaceConfig"]):
+class FaceConfig(ModelConfigBase):
     """Configuration for the facial expression model.
 
     Args:

--- a/hume/models/config/facemesh_config.py
+++ b/hume/models/config/facemesh_config.py
@@ -7,7 +7,7 @@ from hume.models.config.model_config_base import ModelConfigBase
 
 
 @dataclass
-class FacemeshConfig(ModelConfigBase["FacemeshConfig"]):
+class FacemeshConfig(ModelConfigBase):
     """Configuration for the facemesh model."""
 
     @classmethod

--- a/hume/models/config/language_config.py
+++ b/hume/models/config/language_config.py
@@ -8,7 +8,7 @@ from hume.models.config.model_config_base import ModelConfigBase
 
 
 @dataclass
-class LanguageConfig(ModelConfigBase["LanguageConfig"]):
+class LanguageConfig(ModelConfigBase):
     """Configuration for the language emotion model.
 
     Args:

--- a/hume/models/config/model_config_base.py
+++ b/hume/models/config/model_config_base.py
@@ -2,16 +2,13 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Generic, TypeVar
 
 from hume._common.config_base import ConfigBase
 from hume.models import ModelType
 
-T = TypeVar("T")  # Type for subclasses of ModelConfigBase
-
 
 @dataclass
-class ModelConfigBase(ConfigBase["ModelConfigBase"], ABC, Generic[T]):
+class ModelConfigBase(ConfigBase["ModelConfigBase"], ABC):
     """Abstract base class for model configurations."""
 
     @classmethod

--- a/hume/models/config/ner_config.py
+++ b/hume/models/config/ner_config.py
@@ -8,7 +8,7 @@ from hume.models.config.model_config_base import ModelConfigBase
 
 
 @dataclass
-class NerConfig(ModelConfigBase["NerConfig"]):
+class NerConfig(ModelConfigBase):
     """Configuration for the named-entity emotion model.
 
     This model is only available for the batch API.

--- a/hume/models/config/prosody_config.py
+++ b/hume/models/config/prosody_config.py
@@ -8,7 +8,7 @@ from hume.models.config.model_config_base import ModelConfigBase
 
 
 @dataclass
-class ProsodyConfig(ModelConfigBase["ProsodyConfig"]):
+class ProsodyConfig(ModelConfigBase):
     """Configuration for the speech prosody model.
 
     Args:


### PR DESCRIPTION
The generic param for `ModelConfigBase` isn't needed, MyPy doesn't throw errors since it just places `Any` here, but it causes issues when type-checking with Pyright. Since we're explicitly passing in a generic param to `ConfigBase`, it can be omitted.