### PR TITLE
Fix Typing for `submit_job`

### DIFF
--- a/hume/_common/utilities/config_utilities.py
+++ b/hume/_common/utilities/config_utilities.py
@@ -1,5 +1,6 @@
 """Model configuration utilities."""
 
+from collections.abc import Iterable
 from typing import Any, Dict, List, Type
 
 from hume.error.hume_client_exception import HumeClientException
@@ -39,7 +40,7 @@ def config_from_model_type(model_type: ModelType) -> Type[ModelConfigBase]:
     raise HumeClientException(f"Unknown model type {model_type}")
 
 
-def serialize_configs(configs: List[ModelConfigBase]) -> Dict[str, Dict[str, Any]]:
+def serialize_configs(configs: Iterable[ModelConfigBase]) -> Dict[str, Dict[str, Any]]:
     """Convert a list of configs into a dict from model name to serialized model config.
 
     Args:

--- a/hume/_measurement/batch/hume_batch_client.py
+++ b/hume/_measurement/batch/hume_batch_client.py
@@ -1,6 +1,7 @@
 """Batch API client."""
 
 import json
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -68,7 +69,7 @@ class HumeBatchClient(ClientBase):
     def submit_job(
         self,
         urls: List[str],
-        configs: List[ModelConfigBase],
+        configs: Iterable[ModelConfigBase],
         transcription_config: Optional[TranscriptionConfig] = None,
         callback_url: Optional[str] = None,
         notify: Optional[bool] = None,
@@ -82,7 +83,7 @@ class HumeBatchClient(ClientBase):
 
         Args:
             urls (List[str]): List of URLs to media files to be processed.
-            configs (List[ModelConfigBase]): List of model config objects to run on each media URL.
+            configs (Iterable[ModelConfigBase]): Iterable of model config objects to run on each media URL.
             transcription_config (Optional[TranscriptionConfig]): A `TranscriptionConfig` object.
             callback_url (Optional[str]): A URL to which a POST request will be sent upon job completion.
             notify (Optional[bool]): Wether an email notification should be sent upon job completion.
@@ -169,7 +170,7 @@ class HumeBatchClient(ClientBase):
     @classmethod
     def _construct_request(
         cls,
-        configs: List[ModelConfigBase],
+        configs: Iterable[ModelConfigBase],
         urls: List[str],
         text: Optional[List[str]],
         transcription_config: Optional[TranscriptionConfig],

--- a/hume/models/config/model_config_base.py
+++ b/hume/models/config/model_config_base.py
@@ -2,16 +2,13 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Generic, TypeVar
 
 from hume._common.config_base import ConfigBase
 from hume.models import ModelType
 
-T = TypeVar("T")  # Type for subclasses of ModelConfigBase
-
 
 @dataclass
-class ModelConfigBase(ConfigBase["ModelConfigBase"], ABC, Generic[T]):
+class ModelConfigBase(ConfigBase["ModelConfigBase"], ABC):
     """Abstract base class for model configurations."""
 
     @classmethod

--- a/hume/models/config/model_config_base.py
+++ b/hume/models/config/model_config_base.py
@@ -2,13 +2,16 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Generic, TypeVar
 
 from hume._common.config_base import ConfigBase
 from hume.models import ModelType
 
+T = TypeVar("T")  # Type for subclasses of ModelConfigBase
+
 
 @dataclass
-class ModelConfigBase(ConfigBase["ModelConfigBase"], ABC):
+class ModelConfigBase(ConfigBase["ModelConfigBase"], ABC, Generic[T]):
     """Abstract base class for model configurations."""
 
     @classmethod


### PR DESCRIPTION
Fix typing for this example, which raises an error in Pyright:

```python
from hume import HumeBatchClient
from hume.models.config import FaceConfig
from hume.models.config import ProsodyConfig

client = HumeBatchClient("<your-api-key>")
urls = ["https://storage.googleapis.com/hume-test-data/video/armisen-clip.mp4"]
configs = [FaceConfig(identify_faces=True), ProsodyConfig()]
job = client.submit_job(urls, configs)
```

If configs is `FaceConfig | ProsodyConfig` a covariant type like `Iterable` must be used, as `list` as mutable, which would make the assumption possible un-typesafe.

