### PR TITLE
Fix for resumability query param

### DIFF
--- a/hume/_voice/mixins/chat_mixin.py
+++ b/hume/_voice/mixins/chat_mixin.py
@@ -29,6 +29,7 @@ class ChatMixin(ClientBase):
 
         Args:
             config_id (Optional[str]): Config ID.
+            chat_group_id (Optional[str]): Chat group ID.
         """
         uri_base = self._build_endpoint("evi", "chat", Protocol.WS)
 
@@ -42,7 +43,7 @@ class ChatMixin(ClientBase):
         if config_id is not None:
             params["config_id"] = config_id
         if chat_group_id is not None:
-            params["chat_group_id"] = chat_group_id
+            params["resumed_chat_group_id"] = chat_group_id
 
         encoded_params = urllib.parse.urlencode(params)
         uri = f"{uri_base}?{encoded_params}"


### PR DESCRIPTION
The SDK was using the wrong query parameter name for resuming a chat based on a chat group ID