### PR TITLE
Use package version

### DIFF
--- a/src/hume/core/client_wrapper.py
+++ b/src/hume/core/client_wrapper.py
@@ -5,6 +5,7 @@ import typing
 import httpx
 
 from .http_client import AsyncHttpClient, HttpClient
+from importlib.metadata import version
 
 
 class BaseClientWrapper:
@@ -17,7 +18,7 @@ class BaseClientWrapper:
         headers: typing.Dict[str, str] = {
             "X-Fern-Language": "Python",
             "X-Fern-SDK-Name": "hume",
-            "X-Fern-SDK-Version": "1.0.0",
+            "X-Fern-SDK-Version": version("hume"),
         }
         if self.api_key is not None and include_auth:
             headers["X-Hume-Api-Key"] = self.api_key


### PR DESCRIPTION
Tested via

```shell
$ uv pip install -e /Users/twitchard/dev/hume-python-sdk
$ nc -l 4444 &
[1] 25650
$ cat main.py
from hume import AsyncHumeClient
import asyncio
hume = AsyncHumeClient(api_key="xyz", base_url="http://localhost:4444")
async def main():
    await hume.empathic_voice.configs.list_configs()
asyncio.run(main())
$ uv run main.py
GET /v0/evi/configs?page_number=1 HTTP/1.1
Host: localhost:4444
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
User-Agent: python-httpx/0.28.1
X-Fern-Language: Python
X-Fern-SDK-Name: hume
X-Fern-SDK-Version: 0.8.3
```
