### PR TITLE
Respect base_url

### DIFF
--- a/src/hume/empathic_voice/chat/socket_client.py
+++ b/src/hume/empathic_voice/chat/socket_client.py
@@ -231,7 +231,8 @@ class AsyncChatClientWithWebsocket:
         elif api_key is not None:
             query_params = query_params.add("apiKey", api_key)
 
-        return f"wss://api.hume.ai/v0/evi/chat?{query_params}"
+        base = self.client_wrapper.get_base_url().replace('https://', 'wss://').replace('http://', 'ws://')
+        return f"{base}/v0/evi/chat?{query_params}"
 
     @asynccontextmanager
     async def connect(
@@ -378,7 +379,7 @@ class AsyncChatClientWithWebsocket:
         encoded_auth = base64.b64encode(auth.encode()).decode()
         _response = await self.client_wrapper.httpx_client.request(
             method="POST",
-            base_url="https://api.hume.ai/",
+            base_url=self.client_wrapper.get_base_url(),
             path="oauth2-cc/token",
             headers={"Authorization": f"Basic {encoded_auth}"},
             data={"grant_type": "client_credentials"},

--- a/src/hume/expression_measurement/stream/socket_client.py
+++ b/src/hume/expression_measurement/stream/socket_client.py
@@ -211,9 +211,10 @@ class AsyncStreamClientWithWebsocket:
         if api_key is None:
             raise ValueError("An API key is required to connect to the streaming API.")
 
+        base = self.client_wrapper.get_base_url().replace('https://', 'wss://').replace('http://', 'ws://')
         try:
             async with websockets.connect(  # type: ignore[attr-defined]
-                "wss://api.hume.ai/v0/stream/models",
+                f"{base}/v0/stream/models",
                 extra_headers={
                     **self.client_wrapper.get_headers(include_auth=False),
                     "X-Hume-Api-Key": api_key,


### PR DESCRIPTION
`HumeClient` and `AsyncHumeClient` both can be initialized with a `base_url` argument, but it turns out that `base_url` is ignored because `wss://api.hume.ai` is hardcoded in several places.

This PR stops hardcoding `wss://api.hume.ai` and respects the `base_url` passed into the client.