### PR TITLE
Remove dependencies that aren't used anymore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,6 @@ httpx = ">=0.21.2"
 jupyter = { version = "^1.0.0", optional = true}
 pydantic = ">= 1.9.2"
 pydantic-core = "^2.18.2"
-pydub = { version = "^0.25.1", optional = true}
-simpleaudio = { version = "^1.0.4", optional = true}
 sounddevice = { version = "^0.4.6", optional = true}
 typing_extensions = ">= 4.0.0"
 websockets = "^13.1"


### PR DESCRIPTION
I think these dependencies are getting installed when we don't want them:
```
(2) $ uv add hume
Resolved 20 packages in 432ms
   Built simpleaudio==1.0.4
Prepared 2 packages in 1.72s
Installed 19 packages in 19ms
 + aiofiles==24.1.0
 + annotated-types==0.7.0
 + anyio==4.9.0
 + certifi==2025.6.15
 + eval-type-backport==0.2.2
 + exceptiongroup==1.3.0
 + h11==0.16.0
 + httpcore==1.0.9
 + httpx==0.28.1
 + hume==0.9.0
 + idna==3.10
 + pydantic==2.11.7
 + pydantic-core==2.33.2
 + pydub==0.25.1
 + simpleaudio==1.0.4
 + sniffio==1.3.1
 + typing-extensions==4.14.0
 + typing-inspection==0.4.1
 + websockets==13.1
$ uv remove hume
Resolved 1 package in 1ms
Uninstalled 19 packages in 50ms
 - aiofiles==24.1.0
 - annotated-types==0.7.0
 - anyio==4.9.0
 - certifi==2025.6.15
 - eval-type-backport==0.2.2
 - exceptiongroup==1.3.0
 - h11==0.16.0
 - httpcore==1.0.9
 - httpx==0.28.1
 - hume==0.9.0
 - idna==3.10
 - pydantic==2.11.7
 - pydantic-core==2.33.2
 - pydub==0.25.1
 - simpleaudio==1.0.4
 - sniffio==1.3.1
 - typing-extensions==4.14.0
 - typing-inspection==0.4.1
 - websockets==13.1
$ uv add ~/dev/hume-python-sdk/
Resolved 18 packages in 381ms
   Built hume @ file:///Users/twitchard/dev/hume-python-sdk
Prepared 1 package in 629ms
Installed 17 packages in 13ms
 + aiofiles==24.1.0
 + annotated-types==0.7.0
 + anyio==4.9.0
 + certifi==2025.6.15
 + eval-type-backport==0.2.2
 + exceptiongroup==1.3.0
 + h11==0.16.0
 + httpcore==1.0.9
 + httpx==0.28.1
 + hume==0.9.0 (from file:///Users/twitchard/dev/hume-python-sdk)
 + idna==3.10
 + pydantic==2.11.7
 + pydantic-core==2.33.2
 + sniffio==1.3.1
 + typing-extensions==4.14.0
 + typing-inspection==0.4.1
 + websockets==13.1
```