### PR TITLE
Fix device selection

### DIFF
--- a/src/hume/empathic_voice/chat/audio/microphone.py
+++ b/src/hume/empathic_voice/chat/audio/microphone.py
@@ -88,7 +88,7 @@ class Microphone:
         def callback(indata: cffi_backend.buffer, _frames: int, _time: CDataBase, _status: CallbackFlags) -> None:
             event_loop.call_soon_threadsafe(microphone.stream.queue.put_nowait, indata[:])
 
-        with RawInputStream(callback=callback, dtype=cls.DATA_TYPE):
+        with RawInputStream(callback=callback, dtype=cls.DATA_TYPE, device=device):
             yield microphone
 
     def __aiter__(self) -> AsyncIterator[bytes]:


### PR DESCRIPTION
Fixes #234 -- the device selection was not propagating fully into the microphone.py internals.

Tested this locally and confirmed it works by linking the project to the Python quickstart and experimenting with selecting devices in and out of Mac clamshell mode.