### PR TITLE
fix: play_audio_streaming termination

### DIFF
--- a/src/hume/empathic_voice/chat/audio/audio_utilities.py
+++ b/src/hume/empathic_voice/chat/audio/audio_utilities.py
@@ -100,7 +100,7 @@ async def _stream_pcm(
     loop = asyncio.get_running_loop()
     done_event = asyncio.Event()
 
-    def finished():
+    def finished_cb():
         loop.call_soon_threadsafe(done_event.set)
 
     pcm_queue: queue.Queue[Optional[bytes]] = queue.Queue(maxsize=32)
@@ -155,7 +155,7 @@ async def _stream_pcm(
           callback=cb,
           blocksize=blocksize,
           device=device,
-          finished_callback=finished):
+          finished_callback=finished_cb):
             await done_event.wait()
 
     await asyncio.gather(feeder(), player())


### PR DESCRIPTION
`play_audio_streaming` should terminate when its input terminates and playback has finished.

**The problem**
```python
    stream = hume.tts.synthesize_json_streaming(
        utterances=[utterance],
        strip_headers=True
    )

    await play_audio_streaming(base64.b64decode(snippet.audio) async for snippet in stream)
    // Never is reached, process hangs forever
    print('Done!')
```
The problem was the callback name `finished` that was supposed to be triggered by SoundDevice was being shadowed by a boolean.