### PR TITLE
Fix missing base_url

### DIFF
--- a/src/hume/expression_measurement/batch/client_with_utils.py
+++ b/src/hume/expression_measurement/batch/client_with_utils.py
@@ -98,6 +98,7 @@ class BatchClientWithUtils(BatchClient):
 
         _response = self._raw_client._client_wrapper.httpx_client.request(
             "v0/batch/jobs",
+            base_url=self._raw_client._client_wrapper.get_environment().base,
             method="POST",
             files=files,
             request_options=request_options,
@@ -203,6 +204,7 @@ class AsyncBatchClientWithUtils(AsyncBatchClient):
 
         _response = await self._raw_client._client_wrapper.httpx_client.request(
             "v0/batch/jobs",
+            base_url=self._raw_client._client_wrapper.get_environment().base,
             method="POST",
             files=files,
             request_options=request_options,


### PR DESCRIPTION
Follow up to #424.

The #424 pull request ensures that `environment` will always be set appropriately when user specifies `base_url`.

There is a `base_url` property that exists in the internals (this is separate from the `base_url` that is specified by the user when initializing HumeClient). In most cases this was being read from `environment` but in this one .fernignored file it was not. This PR fixes that issue.